### PR TITLE
fix: resolve React 19 hook lint errors from eslint-config-next 16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
                 "@types/react-color": "^3.0.13",
                 "@types/react-dom": "^19",
                 "eslint": "^9.39.4",
-                "eslint-config-next": "16.1.6",
+                "eslint-config-next": "16.2.4",
                 "eslint-config-prettier": "^10.1.8",
-                "typescript": "^5"
+                "typescript": "~5.8.3"
             },
             "engines": {
                 "node": ">=20.9.0",
@@ -107,26 +107,6 @@
                 "url": "https://opencollective.com/babel"
             }
         },
-        "node_modules/@babel/core/node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@babel/core/node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -170,16 +150,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -189,13 +159,6 @@
             "bin": {
                 "semver": "bin/semver.js"
             }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/@babel/helper-globals": {
             "version": "7.28.0",
@@ -266,23 +229,23 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-            "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/types": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -295,13 +258,10 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-            "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -391,21 +351,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-            "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.0",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-            "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -413,9 +373,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -441,6 +401,12 @@
                 "source-map": "^0.5.7",
                 "stylis": "4.2.0"
             }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "license": "MIT"
         },
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
@@ -589,9 +555,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -670,27 +636,14 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/globals": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -744,32 +697,32 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-            "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.10"
+                "@floating-ui/utils": "^0.2.11"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-            "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/core": "^1.7.3",
-                "@floating-ui/utils": "^0.2.10"
+                "@floating-ui/core": "^1.7.5",
+                "@floating-ui/utils": "^0.2.11"
             }
         },
         "node_modules/@floating-ui/react": {
-            "version": "0.27.16",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
-            "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
+            "version": "0.27.19",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+            "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/react-dom": "^2.1.6",
-                "@floating-ui/utils": "^0.2.10",
+                "@floating-ui/react-dom": "^2.1.8",
+                "@floating-ui/utils": "^0.2.11",
                 "tabbable": "^6.0.0"
             },
             "peerDependencies": {
@@ -778,12 +731,12 @@
             }
         },
         "node_modules/@floating-ui/react-dom": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-            "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+            "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/dom": "^1.7.4"
+                "@floating-ui/dom": "^1.7.6"
             },
             "peerDependencies": {
                 "react": ">=16.8.0",
@@ -791,9 +744,9 @@
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
             "license": "MIT"
         },
         "node_modules/@hookform/resolvers": {
@@ -809,41 +762,41 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
-                "@humanwhocodes/retry": "^0.3.0"
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
-        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=18.18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
+                "node": ">=18.18.0"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -861,9 +814,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-            "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -884,9 +837,9 @@
             }
         },
         "node_modules/@img/colour": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-            "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -976,6 +929,9 @@
             "cpu": [
                 "arm"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -991,6 +947,9 @@
             "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1008,6 +967,9 @@
             "cpu": [
                 "ppc64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1023,6 +985,9 @@
             "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1040,6 +1005,9 @@
             "cpu": [
                 "s390x"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1055,6 +1023,9 @@
             "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1072,6 +1043,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1088,6 +1062,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1103,6 +1080,9 @@
             "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1126,6 +1106,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1147,6 +1130,9 @@
             "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1170,6 +1156,9 @@
             "cpu": [
                 "riscv64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1191,6 +1180,9 @@
             "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1214,6 +1206,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1236,6 +1231,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1257,6 +1255,9 @@
             "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1409,15 +1410,15 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
-            "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+            "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "16.1.6",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
-            "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.4.tgz",
+            "integrity": "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1425,9 +1426,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
-            "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+            "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
             "cpu": [
                 "arm64"
             ],
@@ -1441,9 +1442,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
-            "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+            "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
             "cpu": [
                 "x64"
             ],
@@ -1457,11 +1458,14 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
-            "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+            "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1473,11 +1477,14 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
-            "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+            "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1489,11 +1496,14 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
-            "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+            "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1505,11 +1515,14 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
-            "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+            "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1521,9 +1534,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
-            "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+            "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
             "cpu": [
                 "arm64"
             ],
@@ -1537,9 +1550,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
-            "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+            "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
             "cpu": [
                 "x64"
             ],
@@ -1610,17 +1623,17 @@
             }
         },
         "node_modules/@parcel/watcher": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-            "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "detect-libc": "^1.0.3",
+                "detect-libc": "^2.0.3",
                 "is-glob": "^4.0.3",
-                "micromatch": "^4.0.5",
-                "node-addon-api": "^7.0.0"
+                "node-addon-api": "^7.0.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -1630,25 +1643,25 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "@parcel/watcher-android-arm64": "2.5.1",
-                "@parcel/watcher-darwin-arm64": "2.5.1",
-                "@parcel/watcher-darwin-x64": "2.5.1",
-                "@parcel/watcher-freebsd-x64": "2.5.1",
-                "@parcel/watcher-linux-arm-glibc": "2.5.1",
-                "@parcel/watcher-linux-arm-musl": "2.5.1",
-                "@parcel/watcher-linux-arm64-glibc": "2.5.1",
-                "@parcel/watcher-linux-arm64-musl": "2.5.1",
-                "@parcel/watcher-linux-x64-glibc": "2.5.1",
-                "@parcel/watcher-linux-x64-musl": "2.5.1",
-                "@parcel/watcher-win32-arm64": "2.5.1",
-                "@parcel/watcher-win32-ia32": "2.5.1",
-                "@parcel/watcher-win32-x64": "2.5.1"
+                "@parcel/watcher-android-arm64": "2.5.6",
+                "@parcel/watcher-darwin-arm64": "2.5.6",
+                "@parcel/watcher-darwin-x64": "2.5.6",
+                "@parcel/watcher-freebsd-x64": "2.5.6",
+                "@parcel/watcher-linux-arm-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm-musl": "2.5.6",
+                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+                "@parcel/watcher-linux-arm64-musl": "2.5.6",
+                "@parcel/watcher-linux-x64-glibc": "2.5.6",
+                "@parcel/watcher-linux-x64-musl": "2.5.6",
+                "@parcel/watcher-win32-arm64": "2.5.6",
+                "@parcel/watcher-win32-ia32": "2.5.6",
+                "@parcel/watcher-win32-x64": "2.5.6"
             }
         },
         "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-            "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
             "cpu": [
                 "arm64"
             ],
@@ -1666,9 +1679,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-            "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
             "cpu": [
                 "arm64"
             ],
@@ -1686,9 +1699,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-            "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
             "cpu": [
                 "x64"
             ],
@@ -1706,9 +1719,9 @@
             }
         },
         "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-            "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
             "cpu": [
                 "x64"
             ],
@@ -1726,11 +1739,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-            "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1746,11 +1762,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-            "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1766,11 +1785,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-            "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1786,11 +1808,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-            "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1806,11 +1831,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-            "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1826,11 +1854,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-            "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1846,9 +1877,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-            "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1866,9 +1897,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-            "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
             "cpu": [
                 "ia32"
             ],
@@ -1886,9 +1917,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-            "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
             "cpu": [
                 "x64"
             ],
@@ -1903,6 +1934,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rtsao/scc": {
@@ -1928,26 +1972,32 @@
             }
         },
         "node_modules/@tanstack/eslint-plugin-query": {
-            "version": "5.73.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.73.3.tgz",
-            "integrity": "sha512-GmUtnOkRzDuNOq96g3eW5ADKC1nWfrM9RI0kRyQVr87rOl6y+PUgkuVaPxh3R2C0EVODxCS07b9aaWphidl/OA==",
+            "version": "5.99.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.99.2.tgz",
+            "integrity": "sha512-xiazL4CWOHJRDDgs5ZkfW98qlEAisakFDKh1Djc3BIk84tsvt3ow52AC2EiWSMY1q13IB4UI4jSo7yXlC3NL6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/utils": "^8.18.1"
+                "@typescript-eslint/utils": "^8.58.1"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": "^5.4.0 || ^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@tanstack/query-core": {
-            "version": "5.90.12",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.12.tgz",
-            "integrity": "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg==",
+            "version": "5.99.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+            "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -1955,12 +2005,12 @@
             }
         },
         "node_modules/@tanstack/react-query": {
-            "version": "5.90.12",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
-            "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
+            "version": "5.99.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+            "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/query-core": "5.90.12"
+                "@tanstack/query-core": "5.99.2"
             },
             "funding": {
                 "type": "github",
@@ -2043,9 +2093,9 @@
             "license": "MIT"
         },
         "node_modules/@types/lodash": {
-            "version": "4.17.16",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
-            "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+            "version": "4.17.24",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+            "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
             "license": "MIT"
         },
         "node_modules/@types/lodash-es": {
@@ -2058,13 +2108,13 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.17.31",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.31.tgz",
-            "integrity": "sha512-quODOCNXQAbNf1Q7V+fI8WyErOCh0D5Yd31vHnKu4GkSztGQ7rlltAaqXhHhLl33tlVyUXs2386MkANSwgDn6A==",
+            "version": "20.19.39",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+            "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/parse-json": {
@@ -2074,12 +2124,12 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "19.1.2",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
-            "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
+            "version": "19.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+            "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "license": "MIT",
             "dependencies": {
-                "csstype": "^3.0.2"
+                "csstype": "^3.2.2"
             }
         },
         "node_modules/@types/react-color": {
@@ -2096,13 +2146,13 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "19.1.2",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
-            "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "@types/react": "^19.0.0"
+                "@types/react": "^19.2.0"
             }
         },
         "node_modules/@types/react-transition-group": {
@@ -2125,20 +2175,20 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
-            "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+            "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/type-utils": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/scope-manager": "8.59.0",
+                "@typescript-eslint/type-utils": "8.59.0",
+                "@typescript-eslint/utils": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2148,9 +2198,9 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.57.1",
+                "@typescript-eslint/parser": "^8.59.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -2164,16 +2214,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
-            "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+            "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/scope-manager": "8.59.0",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2185,18 +2235,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
-            "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+            "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.57.1",
-                "@typescript-eslint/types": "^8.57.1",
+                "@typescript-eslint/tsconfig-utils": "^8.59.0",
+                "@typescript-eslint/types": "^8.59.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2207,18 +2257,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
-            "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+            "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1"
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2229,9 +2279,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
-            "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+            "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2242,21 +2292,21 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
-            "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+            "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0",
+                "@typescript-eslint/utils": "8.59.0",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2267,13 +2317,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
-            "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2285,21 +2335,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
-            "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+            "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.57.1",
-                "@typescript-eslint/tsconfig-utils": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/project-service": "8.59.0",
+                "@typescript-eslint/tsconfig-utils": "8.59.0",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/visitor-keys": "8.59.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2309,20 +2359,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
-            "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+            "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1"
+                "@typescript-eslint/scope-manager": "8.59.0",
+                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2333,17 +2383,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
-            "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+            "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/types": "8.59.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -2473,6 +2523,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2487,6 +2540,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2501,6 +2557,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2515,6 +2574,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2529,6 +2591,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2543,6 +2608,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2557,6 +2625,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2571,6 +2642,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2909,9 +2983,9 @@
             }
         },
         "node_modules/axe-core": {
-            "version": "4.11.1",
-            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-            "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+            "version": "4.11.3",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+            "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
             "dev": true,
             "license": "MPL-2.0",
             "engines": {
@@ -2919,14 +2993,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/axobject-query": {
@@ -2954,6 +3028,27 @@
                 "npm": ">=6"
             }
         },
+        "node_modules/babel-plugin-macros/node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2965,9 +3060,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.8",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-            "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+            "version": "2.10.20",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+            "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -2977,9 +3072,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2993,7 +3088,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -3003,9 +3098,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "version": "4.28.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
             "dev": true,
             "funding": [
                 {
@@ -3023,11 +3118,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3037,15 +3132,15 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
                 "set-function-length": "^1.2.2"
             },
             "engines": {
@@ -3095,9 +3190,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001760",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
-            "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+            "version": "1.0.30001790",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+            "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3192,9 +3287,10 @@
             "license": "MIT"
         },
         "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/cookie": {
@@ -3244,9 +3340,9 @@
             "license": "MIT"
         },
         "node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
         "node_modules/damerau-levenshtein": {
@@ -3311,9 +3407,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.19",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-            "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+            "version": "1.11.20",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+            "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -3386,16 +3482,13 @@
             }
         },
         "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "license": "Apache-2.0",
             "optional": true,
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
             "engines": {
-                "node": ">=0.10"
+                "node": ">=8"
             }
         },
         "node_modules/doctrine": {
@@ -3436,9 +3529,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.313",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-            "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+            "version": "1.5.343",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
+            "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
             "dev": true,
             "license": "ISC"
         },
@@ -3450,18 +3543,18 @@
             "license": "MIT"
         },
         "node_modules/error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.24.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-            "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+            "version": "1.24.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+            "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3546,16 +3639,16 @@
             }
         },
         "node_modules/es-iterator-helpers": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
-            "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+            "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
+                "call-bind": "^1.0.9",
                 "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.24.1",
+                "es-abstract": "^1.24.2",
                 "es-errors": "^1.3.0",
                 "es-set-tostringtag": "^2.1.0",
                 "function-bind": "^1.1.2",
@@ -3567,8 +3660,7 @@
                 "has-symbols": "^1.1.0",
                 "internal-slot": "^1.1.0",
                 "iterator.prototype": "^1.1.5",
-                "math-intrinsics": "^1.1.0",
-                "safe-array-concat": "^1.1.3"
+                "math-intrinsics": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3715,13 +3807,13 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "16.1.6",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
-            "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
+            "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "16.1.6",
+                "@next/eslint-plugin-next": "16.2.4",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
                 "eslint-plugin-import": "^2.32.0",
@@ -3741,25 +3833,58 @@
                 }
             }
         },
-        "node_modules/eslint-config-next/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+        "node_modules/eslint-config-next/node_modules/globals": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+            "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
-        "node_modules/eslint-config-next/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+        "node_modules/eslint-config-prettier": {
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-import-resolver-node": {
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+            "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "debug": "^3.2.7",
+                "is-core-module": "^2.16.1",
+                "resolve": "^2.0.0-next.6"
             }
         },
-        "node_modules/eslint-config-next/node_modules/eslint-import-resolver-typescript": {
+        "node_modules/eslint-import-resolver-node/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-import-resolver-typescript": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
             "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
@@ -3794,7 +3919,35 @@
                 }
             }
         },
-        "node_modules/eslint-config-next/node_modules/eslint-plugin-import": {
+        "node_modules/eslint-module-utils": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+            "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^3.2.7"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-module-utils/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/eslint-plugin-import": {
             "version": "2.32.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
@@ -3828,7 +3981,25 @@
                 "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
             }
         },
-        "node_modules/eslint-config-next/node_modules/eslint-plugin-import/node_modules/debug": {
+        "node_modules/eslint-plugin-import/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-import/node_modules/debug": {
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
@@ -3838,7 +4009,30 @@
                 "ms": "^2.1.1"
             }
         },
-        "node_modules/eslint-config-next/node_modules/eslint-plugin-jsx-a11y": {
+        "node_modules/eslint-plugin-import/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/eslint-plugin-import/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/eslint-plugin-jsx-a11y": {
             "version": "6.10.2",
             "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
             "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
@@ -3868,7 +4062,38 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
             }
         },
-        "node_modules/eslint-config-next/node_modules/eslint-plugin-react": {
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/eslint-plugin-react": {
             "version": "7.37.5",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
             "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
@@ -3901,10 +4126,10 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
-        "node_modules/eslint-config-next/node_modules/eslint-plugin-react-hooks": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-            "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+        "node_modules/eslint-plugin-react-hooks": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+            "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3918,10 +4143,28 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
             }
         },
-        "node_modules/eslint-config-next/node_modules/minimatch": {
+        "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
@@ -3934,31 +4177,7 @@
                 "node": "*"
             }
         },
-        "node_modules/eslint-config-next/node_modules/resolve": {
-            "version": "2.0.0-next.6",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-            "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "is-core-module": "^2.16.1",
-                "node-exports-info": "^1.6.0",
-                "object-keys": "^1.1.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/eslint-config-next/node_modules/semver": {
+        "node_modules/eslint-plugin-react/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
@@ -3966,72 +4185,6 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/eslint-config-prettier": {
-            "version": "10.1.8",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
-            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "eslint-config-prettier": "bin/cli.js"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint-config-prettier"
-            },
-            "peerDependencies": {
-                "eslint": ">=7.0.0"
-            }
-        },
-        "node_modules/eslint-import-resolver-node": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-            "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^3.2.7",
-                "is-core-module": "^2.13.0",
-                "resolve": "^1.22.4"
-            }
-        },
-        "node_modules/eslint-import-resolver-node/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/eslint-module-utils": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-            "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^3.2.7"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "peerDependenciesMeta": {
-                "eslint": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/eslint-module-utils/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
             }
         },
         "node_modules/eslint-scope": {
@@ -4072,9 +4225,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4263,7 +4416,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -4310,16 +4463,16 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -4369,13 +4522,13 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.9.2",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.9.2.tgz",
-            "integrity": "sha512-R0O3Jdqbfwywpm45obP+8sTgafmdEcUoShQTAV+rB5pi+Y1Px/FYL5qLLRe5tPtBdN1J4jos7M+xN2VV2oEAbQ==",
+            "version": "12.38.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+            "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.9.1",
-                "motion-utils": "^12.8.3",
+                "motion-dom": "^12.38.0",
+                "motion-utils": "^12.36.0",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -4433,6 +4586,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/generator-function": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/gensync": {
@@ -4501,9 +4664,9 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.13.6",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-            "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4527,9 +4690,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
-            "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4557,9 +4720,9 @@
             }
         },
         "node_modules/goober": {
-            "version": "2.1.16",
-            "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-            "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+            "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
             "license": "MIT",
             "peerDependencies": {
                 "csstype": "^3.0.10"
@@ -4657,9 +4820,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -4705,9 +4868,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.1.tgz",
-            "integrity": "sha512-3jatXi9ObIsPGr3N5hGw/vWWcTkq6hUYhpQz4k0wLC+owqWi/LiugIw9x0EdNZ2yGedKN/HzePiBvaJRXa0Ujg==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "license": "MIT"
         },
         "node_modules/import-fresh": {
@@ -4928,14 +5091,15 @@
             }
         },
         "node_modules/is-generator-function": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-            "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bound": "^1.0.3",
-                "get-proto": "^1.0.0",
+                "call-bound": "^1.0.4",
+                "generator-function": "^2.0.0",
+                "get-proto": "^1.0.1",
                 "has-tostringtag": "^1.0.2",
                 "safe-regex-test": "^1.1.0"
             },
@@ -4989,7 +5153,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -5263,16 +5427,16 @@
             "license": "MIT"
         },
         "node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
             "bin": {
                 "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -5358,15 +5522,15 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
@@ -5389,15 +5553,13 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
+                "yallist": "^3.0.2"
             }
         },
         "node_modules/material-colors": {
@@ -5435,7 +5597,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -5467,13 +5629,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -5493,18 +5655,18 @@
             }
         },
         "node_modules/motion-dom": {
-            "version": "12.9.1",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.9.1.tgz",
-            "integrity": "sha512-xqXEwRLDYDTzOgXobSoWtytRtGlf7zdkRfFbrrdP7eojaGQZ5Go4OOKtgnx7uF8sAkfr1ZjMvbCJSCIT2h6fkQ==",
+            "version": "12.38.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+            "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
             "license": "MIT",
             "dependencies": {
-                "motion-utils": "^12.8.3"
+                "motion-utils": "^12.36.0"
             }
         },
         "node_modules/motion-utils": {
-            "version": "12.8.3",
-            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.8.3.tgz",
-            "integrity": "sha512-GYVauZEbca8/zOhEiYOY9/uJeedYQld6co/GJFKOy//0c/4lDqk0zB549sBYqqV2iMuX+uHrY1E5zd8A2L+1Lw==",
+            "version": "12.36.0",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+            "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
             "license": "MIT"
         },
         "node_modules/ms": {
@@ -5555,12 +5717,12 @@
             "license": "MIT"
         },
         "node_modules/next": {
-            "version": "16.2.1",
-            "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
-            "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
+            "version": "16.2.4",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+            "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "16.2.1",
+                "@next/env": "16.2.4",
                 "@swc/helpers": "0.5.15",
                 "baseline-browser-mapping": "^2.9.19",
                 "caniuse-lite": "^1.0.30001579",
@@ -5574,14 +5736,14 @@
                 "node": ">=20.9.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "16.2.1",
-                "@next/swc-darwin-x64": "16.2.1",
-                "@next/swc-linux-arm64-gnu": "16.2.1",
-                "@next/swc-linux-arm64-musl": "16.2.1",
-                "@next/swc-linux-x64-gnu": "16.2.1",
-                "@next/swc-linux-x64-musl": "16.2.1",
-                "@next/swc-win32-arm64-msvc": "16.2.1",
-                "@next/swc-win32-x64-msvc": "16.2.1",
+                "@next/swc-darwin-arm64": "16.2.4",
+                "@next/swc-darwin-x64": "16.2.4",
+                "@next/swc-linux-arm64-gnu": "16.2.4",
+                "@next/swc-linux-arm64-musl": "16.2.4",
+                "@next/swc-linux-x64-gnu": "16.2.4",
+                "@next/swc-linux-x64-musl": "16.2.4",
+                "@next/swc-win32-arm64-msvc": "16.2.4",
+                "@next/swc-win32-x64-msvc": "16.2.4",
                 "sharp": "^0.34.5"
             },
             "peerDependencies": {
@@ -5608,9 +5770,9 @@
             }
         },
         "node_modules/next-auth": {
-            "version": "4.24.13",
-            "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.13.tgz",
-            "integrity": "sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==",
+            "version": "4.24.14",
+            "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
+            "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
             "license": "ISC",
             "dependencies": {
                 "@babel/runtime": "^7.20.13",
@@ -5676,9 +5838,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.36",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "version": "2.0.38",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+            "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
             "dev": true,
             "license": "MIT"
         },
@@ -5820,9 +5982,9 @@
             }
         },
         "node_modules/oidc-token-hash": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
-            "integrity": "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
+            "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
             "license": "MIT",
             "engines": {
                 "node": "^10.13.0 || >=12.0.0"
@@ -5842,6 +6004,24 @@
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
+        },
+        "node_modules/openid-client/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/openid-client/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
         },
         "node_modules/optionator": {
             "version": "0.9.4",
@@ -5983,10 +6163,10 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "devOptional": true,
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -6034,9 +6214,9 @@
             }
         },
         "node_modules/preact": {
-            "version": "10.26.5",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.5.tgz",
-            "integrity": "sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==",
+            "version": "10.29.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+            "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -6066,9 +6246,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.7.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-            "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -6098,10 +6278,13 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -6135,9 +6318,9 @@
             "license": "MIT"
         },
         "node_modules/react": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-            "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+            "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6162,21 +6345,21 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+            "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.4"
+                "react": "^19.2.5"
             }
         },
         "node_modules/react-hook-form": {
-            "version": "7.68.0",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
-            "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
+            "version": "7.73.1",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.73.1.tgz",
+            "integrity": "sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
@@ -6303,12 +6486,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "license": "MIT"
-        },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6331,12 +6508,16 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "version": "2.0.0-next.6",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+            "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.16.0",
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "node-exports-info": "^1.6.0",
+                "object-keys": "^1.1.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -6405,15 +6586,15 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-            "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+            "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.2",
-                "get-intrinsic": "^1.2.6",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "has-symbols": "^1.1.0",
                 "isarray": "^2.0.5"
             },
@@ -6460,13 +6641,13 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.96.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.96.0.tgz",
-            "integrity": "sha512-8u4xqqUeugGNCYwr9ARNtQKTOj4KmYiJAVKXf2CTIivTCR51j96htbMKWDru8H5SaQWpyVgTfOF8Ylyf5pun1Q==",
+            "version": "1.99.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+            "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.0",
-                "immutable": "^5.0.2",
+                "immutable": "^5.1.5",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "bin": {
@@ -6486,9 +6667,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "devOptional": true,
             "license": "ISC",
             "bin": {
@@ -6592,16 +6773,6 @@
                 "@img/sharp-win32-x64": "0.34.5"
             }
         },
-        "node_modules/sharp/node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6646,14 +6817,14 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6931,9 +7102,9 @@
             }
         },
         "node_modules/tabbable": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+            "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
             "license": "MIT"
         },
         "node_modules/tinycolor2": {
@@ -6943,14 +7114,14 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -6978,9 +7149,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6994,7 +7165,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -7004,9 +7175,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7027,6 +7198,19 @@
                 "json5": "^1.0.2",
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
+            }
+        },
+        "node_modules/tsconfig-paths/node_modules/json5": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.0"
+            },
+            "bin": {
+                "json5": "lib/cli.js"
             }
         },
         "node_modules/tslib": {
@@ -7141,16 +7325,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
-            "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+            "version": "8.59.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+            "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.57.1",
-                "@typescript-eslint/parser": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1"
+                "@typescript-eslint/eslint-plugin": "8.59.0",
+                "@typescript-eslint/parser": "8.59.0",
+                "@typescript-eslint/typescript-estree": "8.59.0",
+                "@typescript-eslint/utils": "8.59.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7161,7 +7345,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/unbox-primitive": {
@@ -7184,9 +7368,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -7267,9 +7451,9 @@
             }
         },
         "node_modules/use-isomorphic-layout-effect": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
-            "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+            "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -7373,9 +7557,9 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.19",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7405,15 +7589,16 @@
             }
         },
         "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "license": "ISC",
             "engines": {
                 "node": ">= 6"
@@ -7433,9 +7618,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.0.tgz",
-            "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
@@ -7455,9 +7640,9 @@
             }
         },
         "node_modules/zustand": {
-            "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
-            "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+            "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
         "@types/react-color": "^3.0.13",
         "@types/react-dom": "^19",
         "eslint": "^9.39.4",
-        "eslint-config-next": "16.1.6",
+        "eslint-config-next": "16.2.4",
         "eslint-config-prettier": "^10.1.8",
-        "typescript": "^5"
+        "typescript": "~5.8.3"
     }
 }

--- a/src/app/api/hawkbit/[...path]/route.ts
+++ b/src/app/api/hawkbit/[...path]/route.ts
@@ -82,8 +82,8 @@ export async function GET(request: NextRequest, context: { params: Promise<{ pat
       return new NextResponse(axiosResponse.data, {
         status: axiosResponse.status,
         headers: {
-          'Content-Type': axiosResponse.headers['content-type'] ?? 'application/octet-stream',
-          'Content-Disposition': axiosResponse.headers['content-disposition'] ?? '',
+          'Content-Type': (axiosResponse.headers['content-type'] as string) ?? 'application/octet-stream',
+          'Content-Disposition': (axiosResponse.headers['content-disposition'] as string) ?? '',
         },
       });
     }

--- a/src/app/components/collapsible/index.tsx
+++ b/src/app/components/collapsible/index.tsx
@@ -1,30 +1,20 @@
-import React, { createContext, useContext, useState, useRef, useEffect, ReactNode, RefObject } from 'react';
+import React, { createContext, useContext, useState, useRef, useEffect, ReactNode } from 'react';
 import styles from './styles.module.scss';
 
 type CollapsibleContextType = {
   isOpen: boolean;
   toggle: () => void;
-  contentRef: RefObject<HTMLDivElement | null>;
-  height: string;
 };
 
 const CollapsibleContext = createContext<CollapsibleContextType | null>(null);
 
 export function Collapsible({ children, defaultOpen = false }: { children: ReactNode; defaultOpen?: boolean }) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState('0px');
 
   const toggle = () => setIsOpen((prev) => !prev);
 
-  useEffect(() => {
-    if (contentRef.current) {
-      setHeight(isOpen ? `${contentRef.current.scrollHeight}px` : '0px');
-    }
-  }, [isOpen, children]);
-
   return (
-    <CollapsibleContext.Provider value={{ isOpen, toggle, contentRef, height }}>
+    <CollapsibleContext.Provider value={{ isOpen, toggle }}>
       <div className={styles.collapsible}>{children}</div>
     </CollapsibleContext.Provider>
   );
@@ -46,8 +36,17 @@ function Content({ children }: { children: ReactNode }) {
   const ctx = useContext(CollapsibleContext);
   if (!ctx) throw new Error('Content must be used within Collapsible');
 
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState('0px');
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setHeight(ctx.isOpen ? `${contentRef.current.scrollHeight}px` : '0px');
+    }
+  }, [ctx.isOpen, children]);
+
   return (
-    <div ref={ctx.contentRef} className={styles.collapsible__content} style={{ maxHeight: ctx.height }}>
+    <div ref={contentRef} className={styles.collapsible__content} style={{ maxHeight: height }}>
       <div className={styles.collapsible__inner}>{children}</div>
     </div>
   );

--- a/src/app/hooks/use-filter-multiple-select.ts
+++ b/src/app/hooks/use-filter-multiple-select.ts
@@ -37,8 +37,6 @@ export function useFilterMultipleSelect<T>({
   );
 
   useEffect(() => {
-    console.log('Selected options changed:', selectedOptions);
-
     const isFilterPropertyEmpty = filter.current.property === '' || filter.current.property === undefined;
 
     filter.current.setValues(selectedOptions.map((opt) => [isFilterPropertyEmpty ? '' : '==', getOptionLabel(opt)]));
@@ -47,7 +45,7 @@ export function useFilterMultipleSelect<T>({
     setFilters(newFilters);
 
     onFilterChanged(newFilters);
-  }, [selectedOptions]);
+  }, [selectedOptions, getOptionLabel, filters, setFilters, onFilterChanged]);
 
   return {
     allOptions,

--- a/src/app/x/configuration/components/configuration-form/index.tsx
+++ b/src/app/x/configuration/components/configuration-form/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Checkbox from '@/app/components/checkbox';
 import Select from '@/app/components/select';
 import Input from '@/app/components/input';
@@ -111,6 +111,11 @@ export default function ConfigurationForm({ onSubmit, initialValues, loading = f
   };
 
   const [form, setForm] = useState<FormStateType>(initialValues ?? defaultFormState);
+  const [prevInitialValues, setPrevInitialValues] = useState(initialValues);
+  if (initialValues !== prevInitialValues) {
+    setPrevInitialValues(initialValues);
+    setForm(initialValues ?? defaultFormState);
+  }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -154,12 +159,6 @@ export default function ConfigurationForm({ onSubmit, initialValues, loading = f
 
   const maybeSkeleton = (content: React.ReactNode, width: string | number = '100%', height: string | number = 24) =>
     loading ? <Skeleton width={width} height={height} /> : content;
-
-  useEffect(() => {
-    if (initialValues) {
-      setForm(initialValues);
-    }
-  }, [initialValues]);
 
   return (
     <form className={styles.form} onSubmit={handleSubmit} onReset={handleReset}>

--- a/src/app/x/deployment/components/distribution-tag-form/index.tsx
+++ b/src/app/x/deployment/components/distribution-tag-form/index.tsx
@@ -5,7 +5,7 @@ import Input from '@/app/components/input';
 import TextArea from '@/app/components/text-area';
 import { ActionButtons } from '@/app/components/action-buttons';
 import { useForm } from 'react-hook-form';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ChromePicker } from 'react-color';
 import Text from '@/app/components/text';
 
@@ -27,22 +27,19 @@ export default function DistributionTagForm({ onSubmit, onCancel, defaultValues,
     register,
     handleSubmit,
     formState: { errors },
-    reset,
     setValue,
   } = useForm<FormData>({
-    defaultValues,
+    values: defaultValues as FormData | undefined,
   });
 
-  const [color, setColor] = useState<string>('#FFFFFF');
+  const [color, setColor] = useState<string>(defaultValues?.color ?? '#FFFFFF');
+  const [prevDefaultColor, setPrevDefaultColor] = useState(defaultValues?.color);
+  if (defaultValues?.color !== prevDefaultColor) {
+    setPrevDefaultColor(defaultValues?.color);
+    if (defaultValues?.color) setColor(defaultValues.color);
+  }
 
   const isEditing = mode === 'edit';
-
-  useEffect(() => {
-    if (defaultValues) {
-      reset(defaultValues);
-      if (defaultValues.color) setColor(defaultValues.color);
-    }
-  }, [defaultValues, reset]);
 
   return (
     <>

--- a/src/app/x/deployment/components/target-tag-form/index.tsx
+++ b/src/app/x/deployment/components/target-tag-form/index.tsx
@@ -5,7 +5,7 @@ import Input from '@/app/components/input';
 import TextArea from '@/app/components/text-area';
 import { ActionButtons } from '@/app/components/action-buttons';
 import { useForm } from 'react-hook-form';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ChromePicker } from 'react-color';
 import Text from '@/app/components/text';
 
@@ -27,22 +27,19 @@ export default function TargetTagForm({ onSubmit, onCancel, defaultValues, mode 
     register,
     handleSubmit,
     formState: { errors },
-    reset,
     setValue,
   } = useForm<FormData>({
-    defaultValues,
+    values: defaultValues as FormData | undefined,
   });
 
-  const [color, setColor] = useState<string>('#FFFFFF');
+  const [color, setColor] = useState<string>(defaultValues?.color ?? '#FFFFFF');
+  const [prevDefaultColor, setPrevDefaultColor] = useState(defaultValues?.color);
+  if (defaultValues?.color !== prevDefaultColor) {
+    setPrevDefaultColor(defaultValues?.color);
+    if (defaultValues?.color) setColor(defaultValues.color);
+  }
 
   const isEditing = mode === 'edit';
-
-  useEffect(() => {
-    if (defaultValues) {
-      reset(defaultValues);
-      if (defaultValues.color) setColor(defaultValues.color);
-    }
-  }, [defaultValues, reset]);
 
   return (
     <>

--- a/src/app/x/deployment/components/target-type-form/index.tsx
+++ b/src/app/x/deployment/components/target-type-form/index.tsx
@@ -5,7 +5,7 @@ import Input from '@/app/components/input';
 import TextArea from '@/app/components/text-area';
 import { ActionButtons } from '@/app/components/action-buttons';
 import { useForm } from 'react-hook-form';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ChromePicker } from 'react-color';
 import Text from '@/app/components/text';
 
@@ -27,22 +27,19 @@ export default function TargetTypeForm({ onSubmit, onCancel, defaultValues, mode
     register,
     handleSubmit,
     formState: { errors },
-    reset,
     setValue,
   } = useForm<FormData>({
-    defaultValues,
+    values: defaultValues as FormData | undefined,
   });
 
-  const [color, setColor] = useState<string>('#FFFFFF');
+  const [color, setColor] = useState<string>(defaultValues?.color ?? '#FFFFFF');
+  const [prevDefaultColor, setPrevDefaultColor] = useState(defaultValues?.color);
+  if (defaultValues?.color !== prevDefaultColor) {
+    setPrevDefaultColor(defaultValues?.color);
+    if (defaultValues?.color) setColor(defaultValues.color);
+  }
 
   const isEditing = mode === 'edit';
-
-  useEffect(() => {
-    if (defaultValues) {
-      reset(defaultValues);
-      if (defaultValues.color) setColor(defaultValues.color);
-    }
-  }, [defaultValues, reset]);
 
   return (
     <>

--- a/src/app/x/deployment/containers/deployment-dnd-layout-container/index.tsx
+++ b/src/app/x/deployment/containers/deployment-dnd-layout-container/index.tsx
@@ -64,8 +64,8 @@ export default function DeploymentDndLayoutContainer() {
 
   const [isDragging, setIsDragging] = useState(false);
   const [isDraggingDistribution, setIsDraggingDistribution] = useState(false);
-  const draggedTargets = useRef<Target[]>([]);
-  const draggedDistributions = useRef<Distribution[]>([]);
+  const [draggedTargets, setDraggedTargets] = useState<Target[]>([]);
+  const [draggedDistributions, setDraggedDistributions] = useState<Distribution[]>([]);
 
   const selectedTarget = useTargetsTableStore((state) => state.selectedTarget);
 
@@ -77,13 +77,13 @@ export default function DeploymentDndLayoutContainer() {
     console.log('draggedData', draggedData);
 
     if (isTargetRecord(draggedData)) {
-      draggedTargets.current = Object.values(draggedData);
-      draggedDistributions.current = [];
+      setDraggedTargets(Object.values(draggedData));
+      setDraggedDistributions([]);
     }
     if (isDistributionRecord(draggedData)) {
       setIsDraggingDistribution(true);
-      draggedDistributions.current = Object.values(draggedData);
-      draggedTargets.current = [];
+      setDraggedDistributions(Object.values(draggedData));
+      setDraggedTargets([]);
     }
   }
 
@@ -169,8 +169,8 @@ export default function DeploymentDndLayoutContainer() {
           <DragOverlay>
             {isDragging ? (
               <DraggedItemPreview
-                name={isDraggingDistribution ? draggedDistributions.current[0]?.name : draggedTargets.current[0]?.name}
-                count={isDraggingDistribution ? draggedDistributions.current.length : draggedTargets.current.length}
+                name={isDraggingDistribution ? draggedDistributions[0]?.name : draggedTargets[0]?.name}
+                count={isDraggingDistribution ? draggedDistributions.length : draggedTargets.length}
               />
             ) : null}
           </DragOverlay>

--- a/src/app/x/distributions/containers/distribution-sets-layout-container/index.tsx
+++ b/src/app/x/distributions/containers/distribution-sets-layout-container/index.tsx
@@ -4,7 +4,7 @@ import DistributionSetsCard from '../../components/distribution-sets-card';
 import SoftwareModulesCard from '@/app/x/software-modules/components/software-module-card';
 import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, MouseSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core';
 import DraggedItemPreview from '@/app/components/dragged-item-preview';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Distribution, isDistribution, isDistributionRecord, isSoftwareModule, isSoftwareModuleRecord, SoftwareModule } from '@/entities';
 import { useConfirmDialog } from '@/app/hooks';
 import ConfirmationModal from '@/app/components/confirmation-modal';
@@ -30,10 +30,10 @@ export default function DistributionSetsLayoutContainer() {
   const { refetch: refetchDistributionSets } = useGetPaginatedDistributionSets({ queryOptions: { enabled: false } });
 
   const [isDragging, setIsDragging] = useState(false);
-  const draggedEntity = useRef<'Distribution' | 'Module' | undefined>(undefined);
+  const [draggedEntity, setDraggedEntity] = useState<'Distribution' | 'Module' | undefined>(undefined);
 
-  const draggedDistributions = useRef<Distribution[]>([]);
-  const draggedModules = useRef<SoftwareModule[]>([]);
+  const [draggedDistributions, setDraggedDistributions] = useState<Distribution[]>([]);
+  const [draggedModules, setDraggedModules] = useState<SoftwareModule[]>([]);
 
   const assignConfirmationModal = useConfirmDialog<{ softwareModules: SoftwareModule[]; distributions: Distribution[] }>();
 
@@ -42,14 +42,14 @@ export default function DistributionSetsLayoutContainer() {
     setIsDragging(true);
 
     if (isSoftwareModuleRecord(draggedData)) {
-      draggedEntity.current = 'Module';
-      draggedModules.current = Object.values(draggedData);
-      draggedDistributions.current = [];
+      setDraggedEntity('Module');
+      setDraggedModules(Object.values(draggedData));
+      setDraggedDistributions([]);
     }
     if (isDistributionRecord(draggedData)) {
-      draggedEntity.current = 'Distribution';
-      draggedDistributions.current = Object.values(draggedData);
-      draggedModules.current = [];
+      setDraggedEntity('Distribution');
+      setDraggedDistributions(Object.values(draggedData));
+      setDraggedModules([]);
     }
   }
 
@@ -88,7 +88,7 @@ export default function DistributionSetsLayoutContainer() {
 
   function resetDragging() {
     setIsDragging(false);
-    draggedEntity.current = undefined;
+    setDraggedEntity(undefined);
   }
 
   async function handleAssignModulesToDistributions(params: { distributions: Distribution[]; softwareModules: SoftwareModule[] }) {
@@ -106,19 +106,19 @@ export default function DistributionSetsLayoutContainer() {
   }
 
   const getDraggedItemPreviewProps = useCallback(() => {
-    if (draggedEntity.current === 'Distribution') {
+    if (draggedEntity === 'Distribution') {
       return {
-        name: draggedDistributions.current[0]?.name,
-        count: draggedDistributions.current.length,
+        name: draggedDistributions[0]?.name,
+        count: draggedDistributions.length,
       };
     }
-    if (draggedEntity.current === 'Module') {
+    if (draggedEntity === 'Module') {
       return {
-        name: draggedModules.current[0]?.name,
-        count: draggedModules.current.length,
+        name: draggedModules[0]?.name,
+        count: draggedModules.length,
       };
     }
-  }, []);
+  }, [draggedEntity, draggedDistributions, draggedModules]);
 
   const getDraggedItemsContent = useCallback(() => {
     if (!assignConfirmationModal.data) {

--- a/src/app/x/rollout/components/create-rollout-form/containers/index.tsx
+++ b/src/app/x/rollout/components/create-rollout-form/containers/index.tsx
@@ -27,10 +27,15 @@ export function SelectTargetFilterContainer({ targetFilters, disabled = false, o
     formState: { errors },
   } = useFormContext<CreateRolloutFormData>();
 
+  const [prevHandledCount, setPrevHandledCount] = useState<number | undefined>(undefined);
+  if (selectedTargetsCount !== undefined && selectedTargetsCount !== prevHandledCount) {
+    setPrevHandledCount(selectedTargetsCount);
+    setTargetFilterQuery(undefined);
+  }
+
   useEffect(() => {
     if (selectedTargetsCount) {
       onSelectedTargetsChange(selectedTargetsCount);
-      setTargetFilterQuery(undefined);
     }
   }, [selectedTargetsCount, onSelectedTargetsChange]);
 

--- a/src/app/x/rollout/components/rollouts-table/components/total-targets-per-status-cell/index.tsx
+++ b/src/app/x/rollout/components/rollouts-table/components/total-targets-per-status-cell/index.tsx
@@ -30,16 +30,11 @@ export function TotalTargetsPerStatusCell({ totalTargetsPerStatus }: TotalTarget
     return null;
   }
 
-  for (const status in totalTargetsPerStatus) {
-    const statusKey = status as TotalTargetCountStatus;
-    if (totalTargetsPerStatus[statusKey] === 0) {
-      delete totalTargetsPerStatus[statusKey];
-    }
-  }
+  const nonZeroTargetsPerStatus = Object.entries(totalTargetsPerStatus).filter(([, count]) => count !== 0);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-      {Object.entries(totalTargetsPerStatus).map(([status, count]) => (
+      {nonZeroTargetsPerStatus.map(([status, count]) => (
         <TotalTargetsPerStatus key={status} status={status as TotalTargetCountStatus} count={count} />
       ))}
     </div>

--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -31,7 +31,7 @@ export const authOptions: AuthOptions = {
             username: response.data.username,
             hawkbitAuth: Buffer.from(`${credentials?.username}:${credentials?.password}`).toString('base64'),
           };
-        } catch (error) {
+        } catch {
           console.error('Authentication failed');
           return null;
         }


### PR DESCRIPTION
## Summary
- Resolves the 14 lint errors introduced by the `react-hooks/refs`, `react-hooks/set-state-in-effect`, and `react-hooks/immutability` rules that ship with `eslint-config-next@16.2` (pulled in by the base branch).
- Cleans up two actionable warnings: missing `useEffect` deps in `use-filter-multiple-select`, and an unused `catch` binding in `auth-options`.
- Four `react-hooks/incompatible-library` notices remain intentionally — informational, caused by TanStack Table's `useReactTable` and react-hook-form's `watch()` returning non-memoizable references. React Compiler handles this gracefully.

Base branch is `chore/update-dependencies`; GitHub will auto-retarget to `main` once that PR merges.

### Notable refactors
- **`collapsible`**: height measurement and `contentRef` moved from the shared context into the `Content` subcomponent.
- **Deployment & Distributions DnD containers**: `useRef` for the dragged-items state converted to `useState` so the `DragOverlay` preview re-renders correctly.
- **`configuration-form` & rollout `SelectTargetFilterContainer`**: prop-to-state sync uses the documented "[storing information from previous renders](https://react.dev/reference/react/useState#storing-information-from-previous-renders)" pattern instead of setState-in-useEffect.
- **`distribution-tag-form`, `target-tag-form`, `target-type-form`**: migrated from react-hook-form's one-shot `defaultValues` to its `values` prop so the form syncs automatically when the incoming default data changes.
- **`total-targets-per-status-cell`**: `delete`-on-prop replaced with `Object.entries(...).filter(...)`, matching the pattern in `src/utils/columns-visibility.ts`.